### PR TITLE
fix: 更换README中Star History图表为star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,18 +305,18 @@ npm run dev
   <source
     media="(prefers-color-scheme: dark)"
     srcset="
-      https://api.star-history.com/svg?repos=Shy2593666979/AgentChat&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=Shy2593666979/AgentChat&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=Shy2593666979/AgentChat&type=Date
+      https://star-history.dera.page/svg?repos=Shy2593666979/AgentChat&type=Date
     "
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=Shy2593666979/AgentChat&type=Date"
+    src="https://star-history.dera.page/svg?repos=Shy2593666979/AgentChat&type=Date"
   />
 </picture>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -301,18 +301,18 @@ This project is licensed under the **[MIT License](LICENSE)**
   <source
     media="(prefers-color-scheme: dark)"
     srcset="
-      https://api.star-history.com/svg?repos=Shy2593666979/AgentChat&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=Shy2593666979/AgentChat&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=Shy2593666979/AgentChat&type=Date
+      https://star-history.dera.page/svg?repos=Shy2593666979/AgentChat&type=Date
     "
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=Shy2593666979/AgentChat&type=Date"
+    src="https://star-history.dera.page/svg?repos=Shy2593666979/AgentChat&type=Date"
   />
 </picture>
 


### PR DESCRIPTION
## 问题

当前README中的Star History图表由于GitHub stargazer API限制已经失效，无法正常展示项目星标趋势。

## 修复

将README.md和README_EN.md中图表地址从 \`api.star-history.com\` 更换为 \`star-history.dera.page\`。

新的替代方案基于 \`star-history\` 的fork，使用无需API token的其他数据源，API与前端共用同一域名。

保持不变：图片URL中的功能点（\`type\`、\`theme\` 等参数）均保留原样。