### PR TITLE
add serply web search tool

### DIFF
--- a/src/backend/agentchat/config.yaml
+++ b/src/backend/agentchat/config.yaml
@@ -77,6 +77,9 @@ tools:
   bocha:
     api_key: "sk-**********************"
     endpoint: "https://api.bochaai.com/v1/web-search"
+  # Serply 联网搜索 API 配置（获取 API 密钥: https://serply.io，文档: https://serply.io/docs）
+  serply:
+    api_key: ""
   # You.com Search & Research API 配置（获取 API 密钥: https://ydc-index.io/docs）
   youcom:
     api_key: ""

--- a/src/backend/agentchat/test/test_serply_search.py
+++ b/src/backend/agentchat/test/test_serply_search.py
@@ -1,0 +1,32 @@
+# test_serply_search_simple.py
+from agentchat.tools.web_search.serply_search.action import serply_search
+
+def run_test(name, **kwargs):
+    print(f"\n{'='*20} {name} {'='*20}")
+    try:
+        result = serply_search(**kwargs)
+        print(result[:500] + "..." if len(result) > 500 else result)  # 截断长输出
+    except Exception as e:
+        print(f"❌ 异常: {e}")
+
+if __name__ == "__main__":
+    # 测试 1: 基础搜索
+    run_test(
+        "基础搜索",
+        query="人工智能最新进展",
+        count=3
+    )
+
+    # 测试 2: 限定数量
+    run_test(
+        "限定数量",
+        query="大模型 Agent 框架",
+        count=2
+    )
+
+    # 测试 3: 极端关键词（预期可能无结果）
+    run_test(
+        "无结果测试",
+        query="asdfghjkl123456789!@#",
+        count=1
+    )

--- a/src/backend/agentchat/tools/__init__.py
+++ b/src/backend/agentchat/tools/__init__.py
@@ -2,6 +2,7 @@ from agentchat.tools.send_email.action import send_email
 from agentchat.tools.web_search.google_search.action import google_search
 from agentchat.tools.web_search.tavily_search.action import tavily_search
 from agentchat.tools.web_search.bocha_search.action import bocha_search
+from agentchat.tools.web_search.serply_search.action import serply_search
 from agentchat.tools.arxiv.action import get_arxiv
 from agentchat.tools.get_weather.action import get_weather
 from agentchat.tools.delivery.action import get_delivery_info
@@ -17,6 +18,7 @@ AgentTools = [
     send_email,
     tavily_search,
     bocha_search,
+    serply_search,
     get_weather,
     get_arxiv,
     get_delivery_info,
@@ -41,6 +43,7 @@ AgentToolsWithName = {
     "docx_to_pdf": convert_to_pdf,
     "pdf_to_docx": convert_to_docx,
     "bocha_search": bocha_search,
+    "serply_search": serply_search,
     "youcom_search": youcom_search,
     "youcom_research": youcom_research,
 }
@@ -55,4 +58,5 @@ WeChatTools = {
     "get_weather": get_weather,
     "text_to_image": text_to_image,
     "bocha_search": bocha_search,
+    "serply_search": serply_search,
 }

--- a/src/backend/agentchat/tools/web_search/serply_search/action.py
+++ b/src/backend/agentchat/tools/web_search/serply_search/action.py
@@ -1,0 +1,49 @@
+from langchain.tools import tool
+import requests
+from urllib.parse import urlencode
+
+from agentchat.settings import app_settings
+
+
+@tool("serply_search", parse_docstring=True)
+def serply_search(query: str, count: int = 10) -> str:
+    """
+    使用 Serply Search API 进行网页搜索。
+
+    Args:
+        query (str): 用户的搜索词（必填）
+        count (int): 返回结果条数，范围 1-50，默认 10
+
+    Returns:
+        str: 格式化的搜索结果或错误信息
+    """
+    count = min(max(count, 1), 50)
+    api_key = app_settings.tools.serply.get("api_key")
+    path = urlencode({"q": query, "num": count})
+    headers = {
+        "X-Api-Key": api_key,
+        "Accept": "application/json",
+        # Serply 位于 Cloudflare 之后，默认的 requests User-Agent 会被拦截，需显式指定
+        "User-Agent": "AgentChat",
+    }
+
+    response = requests.get(f"https://api.serply.io/v1/search/{path}", headers=headers)
+
+    if response.status_code == 200:
+        try:
+            results = response.json().get("results") or []
+            if not results:
+                return "未找到相关结果。"
+            formatted_results = ""
+            for idx, item in enumerate(results[:count], start=1):
+                formatted_results += (
+                    f"引用: {idx}\n"
+                    f"标题: {item.get('title', '')}\n"
+                    f"URL: {item.get('link', '')}\n"
+                    f"摘要: {item.get('description', '')}\n\n"
+                )
+            return formatted_results.strip()
+        except Exception as e:
+            return f"搜索API请求失败，原因是：搜索结果解析失败 {str(e)}"
+    else:
+        return f"搜索API请求失败，状态码: {response.status_code}, 错误信息: {response.text}"


### PR DESCRIPTION
## What

Adds Serply as an additional web search tool, alongside the existing Tavily and BoCha tools.

## Why

Gives users another search provider option, following the same pattern used to add BoCha and You.com.

## Notes

- Serply support is optional. The tool is registered like the others, but nothing changes if `tools.serply.api_key` is left blank.
- Follows the existing `bocha_search` tool exactly: same config access pattern (`app_settings.tools.serply.get(...)`), same result formatting style, registered in `AgentTools`, `AgentToolsWithName`, and `WeChatTools`.
- Smoke test added in `src/backend/agentchat/test/test_serply_search.py`, matching `test_bocha_search.py`'s manual, real-API style (this project's existing convention for these tools; no mocked-network test exists for the other search tools either).

## Testing

- Ran the same request/parse logic in `action.py` directly against the real Serply API with a `q=Python asyncio best practices&num=3` query. Got a 200 response and three correctly formatted results (title/URL/snippet).
- Confirmed the "no results" and non-200 error paths return the same formatted-string error messages as `bocha_search`.

Disclosure: I work with Serply. Happy to adjust scope, naming, or drop this
entirely if it isn't a direction you want for the project.
